### PR TITLE
feat: Publish Homebrew cask on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,3 +46,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,5 +37,22 @@ archives:
 checksum:
   name_template: checksums.txt
 
+homebrew_casks:
+  - name: lovr
+    repository:
+      owner: jamillosantos
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: https://github.com/jamillosantos/lovr
+    description: View logs in a human readable way, in the terminal or a built-in web UI
+    # Binaries are not signed/notarized, so strip the quarantine attribute to
+    # keep Gatekeeper from blocking the executable.
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/lovr"]
+          end
+
 changelog:
   use: github-native


### PR DESCRIPTION
Adds a `homebrew_casks` section to goreleaser so each release publishes a cask to [`jamillosantos/homebrew-tap`](https://github.com/jamillosantos/homebrew-tap), making the tool installable with:

```
brew install jamillosantos/tap/lovr
```

- Cask includes a post-install hook that strips the `com.apple.quarantine` attribute, since binaries are not signed/notarized.
- Release workflow now passes the `HOMEBREW_TAP_TOKEN` secret (fine-grained PAT with contents write on the tap repo) to goreleaser.
- Note: casks are macOS-only; Linux users keep using the release tarballs.